### PR TITLE
Add "$" to regex to prevent matching against multiple lags

### DIFF
--- a/tsDyn/R/vec2var.tsDyn.R
+++ b/tsDyn/R/vec2var.tsDyn.R
@@ -195,7 +195,7 @@ vec2var.tsDyn <- function(x){
 
 ## A
   A <- list()
-  for(i in 1:lag) A[[i]] <- co[,grep(paste("\\.l", i, sep=""), colnames(co)), drop=FALSE]
+  for(i in 1:lag) A[[i]] <- co[,grep(paste("\\.l", i, "$", sep=""), colnames(co)), drop=FALSE]
   names(A) <- paste("A", 1:lag, sep="")
 
 ## Rank


### PR DESCRIPTION
in 
```R
for(i in 1:lag) A[[i]] <- co[,grep(paste("\\.l", i, sep=""), colnames(co)), drop=FALSE]
```
the `grep` will match against lags 1 and 10 without the termination term "$"