### PR TITLE
Replace rgl.* functions with *3d

### DIFF
--- a/tsDyn/R/autotriples.rgl.R
+++ b/tsDyn/R/autotriples.rgl.R
@@ -27,10 +27,10 @@
 autotriples.rgl <- function(x, lags=1:2, type=c("lines","points")) {
 	type <- match.arg(type)
 	X <- embedd(x, lags=c(-lags,0))
-	rgl::rgl.clear()
+	rgl::clear3d()
 	if(type=="lines")
-	  rgl::rgl.linestrips(X[,1],X[,2],X[,3])
+	  rgl::lines3d(X[,1],X[,2],X[,3])
 	else if (type=="points")
-	  rgl::rgl.points(X[,1],X[,2],X[,3])
+	  rgl::points3d(X[,1],X[,2],X[,3])
         invisible(NULL)
 }


### PR DESCRIPTION
An upcoming release of rgl will deprecate a large number of rgl.* functions, including some used in tsDyn.  This PR replaces them with equivalents.  It will work both before and after the change.  For details on the deprecation, see

  https://github.com/dmurdoch/rgl/blob/deprecated/vignettes/deprecation.Rmd